### PR TITLE
Add User Agent strings for Hosts package and Engine version.

### DIFF
--- a/packages/amazon-sumerian-hosts-babylon/src/Babylon.js/awspack/LexFeature.js
+++ b/packages/amazon-sumerian-hosts-babylon/src/Babylon.js/awspack/LexFeature.js
@@ -4,6 +4,7 @@ import {LexFeature as CoreLexFeature} from '@amazon-sumerian-hosts/core';
 import {Engine} from '@babylonjs/core/Engines/engine';
 import '@babylonjs/core/Audio/audioSceneComponent';
 import '@babylonjs/core/Audio/audioEngine';
+
 /**
  * @extends core/LexFeature
  * @alias babylonjs/LexFeature
@@ -15,6 +16,11 @@ class LexFeature extends CoreLexFeature {
    */
   _setupAudioContext() {
     this._audioContext = Engine.audioEngine.audioContext;
+  }
+
+  getEngineUserAgentString() {
+    // looks like babylonjs@4.2.2
+    return Engine.NpmPackage;
   }
 }
 

--- a/packages/amazon-sumerian-hosts-babylon/src/Babylon.js/awspack/TextToSpeechFeature.js
+++ b/packages/amazon-sumerian-hosts-babylon/src/Babylon.js/awspack/TextToSpeechFeature.js
@@ -88,6 +88,11 @@ class TextToSpeechFeature extends CoreTextToSpeechFeature {
   _createSpeech(text, speechmarks, audioConfig) {
     return new Speech(this, text, speechmarks, audioConfig);
   }
+
+  getEngineUserAgentString() {
+    // looks like babylonjs@4.2.2
+    return Engine.NpmPackage;
+  }
 }
 
 export default TextToSpeechFeature;

--- a/packages/amazon-sumerian-hosts-babylon/test/unit/awspack/TextToSpeechFeature.spec.js
+++ b/packages/amazon-sumerian-hosts-babylon/test/unit/awspack/TextToSpeechFeature.spec.js
@@ -6,6 +6,7 @@ import {Messenger} from '@amazon-sumerian-hosts/core';
 import {aws} from '@amazon-sumerian-hosts/babylon';
 import {Sound} from '@babylonjs/core/Audio/sound';
 import {TransformNode} from '@babylonjs/core/Meshes/transformNode';
+import {Engine} from '@babylonjs/core/Engines/engine';
 import describeEnvironment from '../EnvironmentHarness';
 
 describeEnvironment('TextToSpeechFeature', options => {
@@ -17,6 +18,7 @@ describeEnvironment('TextToSpeechFeature', options => {
 
     // mock AWS.Polly
     const mockPolly = jasmine.createSpyObj('Polly', ['describeVoices']);
+    mockPolly.config = {customUserAgent: 'abc'};
     mockPolly.describeVoices.and.returnValue({
       promise: jasmine.createSpy().and.resolveTo({
         Voices: [
@@ -64,6 +66,20 @@ describeEnvironment('TextToSpeechFeature', options => {
       mockPresigner,
       mockNeuralVersion
     );
+  });
+
+  describe('Custom User Agent', () => {
+    it('should set the babylon version in the user agent', async () => {
+      // Shows the original user agent from the mock is still here
+      expect(
+        aws.TextToSpeechFeature.SERVICES.polly.config.customUserAgent
+      ).toContain('abc');
+
+      // Shows the babylonjs version is in there
+      expect(
+        aws.TextToSpeechFeature.SERVICES.polly.config.customUserAgent
+      ).toContain(Engine.NpmPackage);
+    });
   });
 
   describe('_createSpeech', () => {

--- a/packages/amazon-sumerian-hosts-core/src/core/Utils.js
+++ b/packages/amazon-sumerian-hosts-core/src/core/Utils.js
@@ -166,6 +166,18 @@ class Utils {
     return Math.floor(Math.random() * (max - min)) + min;
   }
 
+  static addStringOnlyOnce(stringToManipulate, stringToAdd) {
+    if (stringToManipulate == null) {
+      return stringToAdd;
+    }
+
+    if (stringToManipulate.indexOf(stringToAdd) !== -1) {
+      return stringToManipulate;
+    }
+
+    return stringToManipulate.concat(' ', stringToAdd);
+  }
+
   /**
    * Appends the Sumerian Hosts custom user-agent to a string if it is not
    * already present.
@@ -176,18 +188,16 @@ class Utils {
    *
    * @returns {string}
    */
-  static withCustomUserAgent(currentUserAgent) {
-    const sumerianHostsUserAgent = 'request-source/SumerianHosts';
+  static addCoreUserAgentComponent(currentUserAgent) {
+    const sumerianHostsUserAgent = `SumerianHosts-${Utils.getVersion()}`;
+    return Utils.addStringOnlyOnce(currentUserAgent, sumerianHostsUserAgent);
+  }
 
-    if (currentUserAgent == null) {
-      return sumerianHostsUserAgent;
-    }
-
-    if (currentUserAgent.indexOf(sumerianHostsUserAgent) !== -1) {
-      return currentUserAgent;
-    }
-
-    return currentUserAgent.concat(' ', sumerianHostsUserAgent);
+  static getVersion() {
+    // HOSTS_VERSION  is defined by Webpack, to the version of the library
+    // Either a git commit or a release version
+    // eslint-disable-next-line no-undef
+    return HOSTS_VERSION;
   }
 }
 

--- a/packages/amazon-sumerian-hosts-core/src/core/awspack/AbstractTextToSpeechFeature.js
+++ b/packages/amazon-sumerian-hosts-core/src/core/awspack/AbstractTextToSpeechFeature.js
@@ -225,13 +225,23 @@ class AbstractTextToSpeechFeature extends AbstractHostFeature {
 
     // Add sumerian hosts user-agent
     if (polly.config) {
-      polly.config.customUserAgent = Utils.withCustomUserAgent(
+      polly.config.customUserAgent = Utils.addCoreUserAgentComponent(
         polly.config.customUserAgent
+      );
+
+      polly.config.customUserAgent = Utils.addStringOnlyOnce(
+        polly.config.customUserAgent,
+        this.prototype.getEngineUserAgentString()
       );
     }
     if (presigner.service && presigner.service.config) {
-      presigner.service.config.customUserAgent = Utils.withCustomUserAgent(
+      presigner.service.config.customUserAgent = Utils.addCoreUserAgentComponent(
         presigner.service.config.customUserAgent
+      );
+
+      presigner.service.config.customUserAgent = Utils.addStringOnlyOnce(
+        presigner.service.config.customUserAgent,
+        this.prototype.getEngineUserAgentString()
       );
     }
 
@@ -1135,6 +1145,14 @@ class AbstractTextToSpeechFeature extends AbstractHostFeature {
     delete this._speechCache;
 
     super.discard();
+  }
+
+  /**
+   *
+   * @returns The useragent string for the engine you are using, e.g. 'babylonjs/5.1.0'
+   */
+  getEngineUserAgentString() {
+    return 'UnknownEngine';
   }
 }
 

--- a/packages/amazon-sumerian-hosts-core/src/core/awspack/LexFeature.js
+++ b/packages/amazon-sumerian-hosts-core/src/core/awspack/LexFeature.js
@@ -54,7 +54,7 @@ class LexFeature extends Messenger {
       throw Error('Cannot initialize Lex feature. LexRuntime must be defined');
     }
     if (lexRuntime.config) {
-      lexRuntime.config.customUserAgent = Utils.withCustomUserAgent(
+      lexRuntime.config.customUserAgent = Utils.addCoreUserAgentComponent(
         lexRuntime.config.customUserAgent
       );
     }

--- a/packages/amazon-sumerian-hosts-core/src/core/awspack/LexFeature.js
+++ b/packages/amazon-sumerian-hosts-core/src/core/awspack/LexFeature.js
@@ -57,6 +57,10 @@ class LexFeature extends Messenger {
       lexRuntime.config.customUserAgent = Utils.addCoreUserAgentComponent(
         lexRuntime.config.customUserAgent
       );
+      lexRuntime.config.customUserAgent = Utils.addStringOnlyOnce(
+        lexRuntime.config.customUserAgent,
+        this.getEngineUserAgentString()
+      );
     }
     this._lexRuntime = lexRuntime;
 
@@ -246,6 +250,14 @@ class LexFeature extends Messenger {
     this.emit(this.constructor.EVENTS.recordEnd);
 
     return this._processWithAudio(result, this._audioContext.sampleRate);
+  }
+
+  /**
+   *
+   * @returns The useragent string for the engine you are using, e.g. 'babylonjs/5.1.0'
+   */
+  getEngineUserAgentString() {
+    return 'UnknownEngine';
   }
 }
 

--- a/packages/amazon-sumerian-hosts-core/src/core/index.js
+++ b/packages/amazon-sumerian-hosts-core/src/core/index.js
@@ -20,6 +20,8 @@ import animpack from './animpack';
 
 import aws from './awspack';
 
+const Version = Utils.getVersion();
+
 const {
   Easing,
   AnimationFeature,
@@ -185,4 +187,8 @@ export {
    * @see module:core/awspack.Speech
    */
   Speech,
+  /**
+   * The Version of the Sumerian Hosts library
+   */
+  Version,
 };

--- a/packages/amazon-sumerian-hosts-core/test/unit/awspack/AbstractTextToSpeechFeature.spec.js
+++ b/packages/amazon-sumerian-hosts-core/test/unit/awspack/AbstractTextToSpeechFeature.spec.js
@@ -9,6 +9,7 @@ import {
   AbstractTextToSpeechFeature,
   AbstractSpeech,
   Deferred,
+  Version,
 } from '@amazon-sumerian-hosts/core';
 import describeEnvironment from '../EnvironmentHarness';
 
@@ -209,7 +210,7 @@ describeEnvironment('AbstractTextToSpeechFeature', () => {
       mockPolly.config = {
         customUserAgent: null,
       };
-      const sumerianUserAgent = 'request-source/SumerianHosts';
+      const sumerianUserAgent = `SumerianHosts-${Version} UnknownEngine`;
 
       expect(mockPolly.config.customUserAgent).not.toEqual(sumerianUserAgent);
 
@@ -227,7 +228,7 @@ describeEnvironment('AbstractTextToSpeechFeature', () => {
       mockPolly.config = {
         customUserAgent: customerUserAgent,
       };
-      const sumerianUserAgent = 'request-source/SumerianHosts';
+      const sumerianUserAgent = `SumerianHosts-${Version} UnknownEngine`;
 
       expect(mockPolly.config.customUserAgent).toEqual(customerUserAgent);
 
@@ -242,11 +243,11 @@ describeEnvironment('AbstractTextToSpeechFeature', () => {
       );
     });
 
-    it('should not append to the Polly service customeUserAgent the sumeriand designated value more than once', async () => {
+    it('should not append to the Polly service customUserAgent the sumerian designated value more than once', async () => {
       mockPolly.config = {
         customUserAgent: null,
       };
-      const sumerianUserAgent = 'request-source/SumerianHosts';
+      const sumerianUserAgent = `SumerianHosts-${Version} UnknownEngine`;
 
       expect(mockPolly.config.customUserAgent).not.toEqual(sumerianUserAgent);
 
@@ -272,7 +273,7 @@ describeEnvironment('AbstractTextToSpeechFeature', () => {
       mockPresigner.service.config = {
         customUserAgent: null,
       };
-      const sumerianUserAgent = 'request-source/SumerianHosts';
+      const sumerianUserAgent = `SumerianHosts-${Version} UnknownEngine`;
 
       expect(mockPresigner.service.config.customUserAgent).not.toEqual(
         sumerianUserAgent
@@ -295,7 +296,7 @@ describeEnvironment('AbstractTextToSpeechFeature', () => {
       mockPresigner.service.config = {
         customUserAgent: customerUserAgent,
       };
-      const sumerianUserAgent = 'request-source/SumerianHosts';
+      const sumerianUserAgent = `SumerianHosts-${Version} UnknownEngine`;
 
       expect(mockPresigner.service.config.customUserAgent).toEqual(
         customerUserAgent
@@ -317,7 +318,7 @@ describeEnvironment('AbstractTextToSpeechFeature', () => {
       mockPresigner.service.config = {
         customUserAgent: null,
       };
-      const sumerianUserAgent = 'request-source/SumerianHosts';
+      const sumerianUserAgent = `SumerianHosts-${Version} UnknownEngine`;
 
       expect(mockPresigner.service.config.customUserAgent).not.toEqual(
         sumerianUserAgent

--- a/packages/amazon-sumerian-hosts-core/test/unit/awspack/LexFeature.spec.js
+++ b/packages/amazon-sumerian-hosts-core/test/unit/awspack/LexFeature.spec.js
@@ -2,7 +2,7 @@
 /* eslint-disable no-underscore-dangle */
 // Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 // SPDX-License-Identifier: MIT-0
-import {LexFeature} from '@amazon-sumerian-hosts/core';
+import {LexFeature, Version} from '@amazon-sumerian-hosts/core';
 import describeEnvironment from '../EnvironmentHarness';
 
 describeEnvironment('LexFeature', () => {
@@ -25,7 +25,7 @@ describeEnvironment('LexFeature', () => {
       mockLexRuntime.config = {
         customUserAgent: null,
       };
-      const sumerianUserAgent = 'request-source/SumerianHosts';
+      const sumerianUserAgent = `SumerianHosts-${Version}`;
 
       lexFeature = new LexFeature(mockLexRuntime);
 
@@ -36,7 +36,7 @@ describeEnvironment('LexFeature', () => {
       mockLexRuntime.config = {
         customUserAgent: 'UserDefined',
       };
-      const sumerianUserAgent = 'request-source/SumerianHosts';
+      const sumerianUserAgent = `SumerianHosts-${Version}`;
 
       lexFeature = new LexFeature(mockLexRuntime);
 

--- a/packages/amazon-sumerian-hosts-core/test/unit/awspack/LexFeature.spec.js
+++ b/packages/amazon-sumerian-hosts-core/test/unit/awspack/LexFeature.spec.js
@@ -29,7 +29,11 @@ describeEnvironment('LexFeature', () => {
 
       lexFeature = new LexFeature(mockLexRuntime);
 
-      expect(mockLexRuntime.config.customUserAgent).toEqual(sumerianUserAgent);
+      expect(mockLexRuntime.config.customUserAgent).toContain(
+        sumerianUserAgent
+      );
+
+      expect(mockLexRuntime.config.customUserAgent).toContain('UnknownEngine');
     });
 
     it('should append sumerian designated value to user defined LexRuntime service customUserAgent', () => {
@@ -40,7 +44,7 @@ describeEnvironment('LexFeature', () => {
 
       lexFeature = new LexFeature(mockLexRuntime);
 
-      expect(mockLexRuntime.config.customUserAgent).toEqual(
+      expect(mockLexRuntime.config.customUserAgent).toContain(
         `UserDefined ${sumerianUserAgent}`
       );
     });

--- a/packages/amazon-sumerian-hosts-three/src/three.js/awspack/TextToSpeechFeature.js
+++ b/packages/amazon-sumerian-hosts-three/src/three.js/awspack/TextToSpeechFeature.js
@@ -16,6 +16,13 @@ import Speech from './Speech';
  */
 
 /**
+ * Threejs REVISION object
+ *
+ * @external "THREE.REVISION"
+ * @see https://threejs.org/docs/#api/en/constants/Core
+ */
+
+/**
  * @extends core/TextToSpeechFeature
  * @alias threejs/TextToSpeechFeature
  */
@@ -86,6 +93,10 @@ class TextToSpeechFeature extends CoreTextToSpeechFeature {
 
   _createSpeech(text, speechmarks, audioConfig) {
     return new Speech(this, text, speechmarks, audioConfig);
+  }
+
+  getEngineUserAgentString() {
+    return `Three.js-${THREE.REVISION}`;
   }
 }
 

--- a/packages/amazon-sumerian-hosts-three/test/unit/awspack/TextToSpeechFeature.spec.js
+++ b/packages/amazon-sumerian-hosts-three/test/unit/awspack/TextToSpeechFeature.spec.js
@@ -15,6 +15,7 @@ describeEnvironment('TextToSpeechFeature', () => {
 
     // mock AWS.Polly
     const mockPolly = jasmine.createSpyObj('Polly', ['describeVoices']);
+    mockPolly.config = {customUserAgent: 'abc'};
     mockPolly.describeVoices.and.returnValue({
       promise: jasmine.createSpy().and.resolveTo({
         Voices: [
@@ -62,6 +63,20 @@ describeEnvironment('TextToSpeechFeature', () => {
       mockPresigner,
       mockNeuralVersion
     );
+  });
+
+  describe('Custom User Agent', () => {
+    it('should set the three revision as the user agent', async () => {
+      // Shows the original user agent from the mock is still here
+      expect(
+        aws.TextToSpeechFeature.SERVICES.polly.config.customUserAgent
+      ).toContain('abc');
+
+      // Shows the three version is in there
+      expect(
+        aws.TextToSpeechFeature.SERVICES.polly.config.customUserAgent
+      ).toContain(`Three.js-${THREE.REVISION}`);
+    });
   });
 
   describe('_createSpeech', () => {

--- a/packages/demos-babylon/src/chatbotDemo.html
+++ b/packages/demos-babylon/src/chatbotDemo.html
@@ -8,12 +8,6 @@
 
     <link rel="stylesheet" href="chatbotDemo.css" />
 
-    <!-- Sumerian Host dependencies -->
-    <script
-      type="text/javascript"
-      src="https://sdk.amazonaws.com/js/aws-sdk-2.645.0.min.js"
-    ></script>
-
     <!-- Demo logic -->
     <script type="module" src="../dist/chatbotDemo.js"></script>
   </head>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,6 +32,11 @@ if (process.env.ENGINE === 'core') {
 }
 
 let devServerOnlyEntryPoints = {};
+
+// During a github build we pull the git commit sha out of the environment
+// for local builds we hardcode 'development', so we can differentiate these(i.e. in dev the commit hash is not really accurate)
+const HOSTS_VERSION = JSON.stringify(process.env.GITHUB_SHA || "development");
+
 let prodOnlyExternals = [];
 
 if (isDevServer) {
@@ -128,6 +133,7 @@ module.exports = {
       banner: `Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\nSPDX-License-Identifier: MIT-0`,
       entryOnly: true,
     }),
+    new webpack.DefinePlugin({HOSTS_VERSION})
   ],
   devServer: {
     devMiddleware: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -35,7 +35,7 @@ let devServerOnlyEntryPoints = {};
 
 // During a github build we pull the git commit sha out of the environment
 // for local builds we hardcode 'development', so we can differentiate these(i.e. in dev the commit hash is not really accurate)
-const HOSTS_VERSION = JSON.stringify(process.env.GITHUB_SHA || "development");
+const HOSTS_VERSION = JSON.stringify(process.env.GITHUB_SHA || 'development');
 
 let prodOnlyExternals = [];
 
@@ -133,7 +133,7 @@ module.exports = {
       banner: `Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.\nSPDX-License-Identifier: MIT-0`,
       entryOnly: true,
     }),
-    new webpack.DefinePlugin({HOSTS_VERSION})
+    new webpack.DefinePlugin({HOSTS_VERSION}),
   ],
   devServer: {
     devMiddleware: {


### PR DESCRIPTION
The Sumerian Hosts now automatically add a version string for both the hosts package as well as the engine integration.

The Hosts version number is the git commit hash. This is set by github actions during a build, but using a local build will default to 'development'. We may want to switch this to release number which should be a simple change

The Engine version number identifies the version of Babylon or Three being used.

There are some unit tests
I validated by looking at the network inspector in the integration tests/demos for both lex(babylon-only) and polly

Example header from the babylon lex sample
`X-Amz-User-Agent: aws-sdk-js/2.1117.0 SumerianHosts-development babylonjs@4.2.2 promise`

The header does not get added to the presigned URLs we use for the MP3 download from Polly.
I don't think this is a problem, however, as we always send a second request to get the visemes which does have this header.